### PR TITLE
CBBF-39: Actually remove Lucene indexes from HAPI FHIR server (for reals this time)

### DIFF
--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/FhirServerConfig.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/FhirServerConfig.java
@@ -153,13 +153,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 		 * are: https://groups.google.com/forum/#!topic/hapi-fhir/lF9b_cLfgA4.
 		 */
 		extraProperties.put("hibernate.search.autoregister_listeners", "false");
-
-		/*
-		 * This property was used to disable Lucene in HAPI 1.4. Pretty sure
-		 * it's not needed anymore, but seems worth keeping around, just in
-		 * case.
-		 */
-		// extraProperties.put("hibernate.search.indexing_strategy", "manual");
+		extraProperties.put("hibernate.search.indexing_strategy", "manual");
 		return extraProperties;
 	}
 


### PR DESCRIPTION
http://issues.hhsdevcloud.us/browse/CBBF-39

See my commit message for an explanation.