### PR TITLE
CBBD-248: Make the number of server DB connections configurable

### DIFF
--- a/bluebutton-server-app/src/main/config/server-config-healthapt.sh
+++ b/bluebutton-server-app/src/main/config/server-config-healthapt.sh
@@ -19,7 +19,7 @@ scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Use GNU getopt to parse the options passed to this script.
 TEMP=`getopt \
 	-o h:m:as:k:t:w:u:n:p:c: \
-	--long serverhome:,managementport:,auth,httpsport:,keystore:,truststore:,war:,dburl:,dbusername:,dbpassword:,:dbconnectionsmax \
+	--long serverhome:,managementport:,auth,httpsport:,keystore:,truststore:,war:,dburl:,dbusername:,dbpassword:,dbconnectionsmax: \
 	-n 'bluebutton-server-app-server-config-healthapt.sh' -- "$@"`
 if [ $? != 0 ] ; then echo "Terminating." >&2 ; exit 1 ; fi
 

--- a/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/FhirServerConfig.java
+++ b/bluebutton-server-app/src/main/java/gov/hhs/cms/bluebutton/server/app/FhirServerConfig.java
@@ -148,7 +148,7 @@ public class FhirServerConfig extends BaseJavaConfigDstu3 {
 	public DataSource dataSource(@Value("${" + PROP_DB_URL + "}") String url,
 			@Value("${" + PROP_DB_USERNAME + "}") String username,
 			@Value("${" + PROP_DB_PASSWORD + "}") String password,
-			@Value("${" + PROP_DB_CONNECTIONS_MAX + "}") String connectionsMaxText, MetricRegistry metricRegistry) {
+			@Value("${" + PROP_DB_CONNECTIONS_MAX + ":-1}") String connectionsMaxText, MetricRegistry metricRegistry) {
 		HikariDataSource poolingDataSource = new HikariDataSource();
 
 		poolingDataSource.setJdbcUrl(url);


### PR DESCRIPTION
The previous/default approach of calculating a value based on the number
of processors is okay, but doesn't really allow for multi-system
environments where the FHIR server has less/more CPUs than the ETL
server.