### PR TITLE
CBBF-59: Server config script not configuring servers to listen on all IPs

### DIFF
--- a/bluebutton-server-app/src/main/config/server-config-healthapt.sh
+++ b/bluebutton-server-app/src/main/config/server-config-healthapt.sh
@@ -229,10 +229,8 @@ if (outcome == success) of /subsystem=datasources/data-source=TestProdFHIR:read-
 end-if
 
 # Configure the server to listen on all configured IPs.
-if (result != undefined) of /interface=public:read-attribute(name=inet-address)
-	/interface=public:undefine-attribute(name=inet-address)
-	/interface=public:write-attribute(name=any-address,value=true)
-end-if
+/interface=public:undefine-attribute(name=inet-address)
+/interface=public:write-attribute(name=any-address,value=true)
 
 # Reload the server to apply those changes.
 :reload


### PR DESCRIPTION
Removing a broken (and unneeded) if clause.

This was preventing the script from correctly configuring the server to
listen on all IPs. Instead, it was only listening on the loopback
address.

http://issues.hhsdevcloud.us/browse/CBBF-59