### PR TITLE
CBBF-60: Dialing down the log spamming from ETL

### DIFF
--- a/bluebutton-server-app/src/main/resources/logback.xml
+++ b/bluebutton-server-app/src/main/resources/logback.xml
@@ -28,6 +28,11 @@
 	<logger name="ca.uhn.fhir.jpa.dao.BaseHapiFhirResourceDao" level="warn" />
 	<logger name="ca.uhn.fhir.jpa.dao.dstu3.FhirSystemDaoDstu3" level="warn" />
 
+	<!-- Because the ETL service uses the `If-None-Exists` header, every create 
+		operation logs one or more of these events, too. Turning down to avoid those 
+		silly amounts of log spam. -->
+	<logger name="ca.uhn.fhir.jpa.dao.SearchBuilder" level="warn" />
+
 	<root level="info">
 		<appender-ref ref="FILE" />
 	</root>


### PR DESCRIPTION
Every create operation now runs a search (thanks to our `If-None-Exists` usage), and every one of those gets logged.

It doesn't appear to be slowing down the FHIR server any, but it will eventually eat a ton of disk space. And it makes the logs almost useless -- can't find anything else in there with all of the noise.

http://issues.hhsdevcloud.us/browse/CBBF-60